### PR TITLE
Place HMD at proper height in 6DOF mode

### DIFF
--- a/L4D2VR/sdk/sdk.h
+++ b/L4D2VR/sdk/sdk.h
@@ -1254,7 +1254,7 @@ public:
 	virtual void *sub_10019E10() = 0;
 	virtual void *sub_1001A090() = 0;
 	virtual void *sub_10019870() = 0;
-	virtual void *GetViewOffset() = 0;
+	virtual const Vector& GetViewOffset() = 0;
 	virtual void *SetViewOffset() = 0;
 	virtual void *GetGroundVelocityToApply() = 0;
 	virtual void *ShouldInterpolate() = 0;

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -97,6 +97,8 @@ VR::VR(Game *game)
     m_Overlay->SetOverlayCurvature(m_MainMenuHandle, 0.15f);
     m_Overlay->SetOverlayMouseScale(m_MainMenuHandle, &mouseScaleMenu);
 
+    vr::VRCompositor()->SetTrackingSpace(vr::TrackingUniverseStanding);
+
     UpdatePosesAndActions();
 
     m_IsInitialized = true;
@@ -935,6 +937,7 @@ void VR::UpdateHMDAngles() {
 void VR::ResetPosition()
 {
     m_Center = m_HmdPose.TrackedDevicePos;
+    m_Center.z = 0;
 }
 
 void VR::UpdateTracking()
@@ -960,6 +963,9 @@ void VR::UpdateTracking()
     UpdateHMDAngles();
 
     m_HmdPosRelative = hmdPosCorrected * m_VRScale;
+    // 64 is the eye view height from the player's base position
+    // we subtract this here so that we place the HMD height at the actual player height if 6DOF is enabled
+    m_HmdPosRelative.z -= 64;
 
     // Roomscale setup
     /*Vector cameraMovingDirection = m_Center - m_SetupOriginPrev;


### PR DESCRIPTION
This places the camera at the proper offset from the floor in 6DOF mode. You no longer need to calibrate your height (although you do still need to calibrate your center position).